### PR TITLE
[Configs] Define configuration for all the objects

### DIFF
--- a/objectPerformance/cfg_caching/V22.yaml
+++ b/objectPerformance/cfg_caching/V22.yaml
@@ -12,6 +12,7 @@ V22:
         gmtMuon: [Pt, Eta, Phi, Z0, D0, IPt, IEta, IPhi, IZ0, ID0, Chg, Iso, Qual, Beta, Bx]
         gmtTkMuon: [Pt, Eta, Phi, Z0, D0, IPt, IEta, IPhi, IZ0, ID0, Chg, Iso, Qual, Beta, NStubs, Bx]
         tkElectron: [Pt, Et, Eta, Phi, Chg, Bx, TrkIso, PfIso, PuppiIso, zVtx, HwQual, EGRefPt, EGRefEta, EGRefPhi, HGC, PassesLooseTrackID, PassesPhotonID]
+        EG: [Pt, Et, Eta, Phi, Bx, Iso, HwQual, HGC, PassesPhotonID, PassesLooseTrackID]
   TT:
     ntuple_path: /eos/cms/store/cmst3/group/l1tr/phase2Menu/EmuDev/TT_TuneCP5_14TeV-powheg-pythia8/TT_PU200_v22/220407_094308/0000//L1NtuplePhaseII_Step1_*.root
     trees_branches:
@@ -24,20 +25,25 @@ V22:
         phase1PuppiMHT: "all"
         trackerHT: "all"
         phase1PuppiHT: "all"
-        seededConePuppiJet: ['Pt', 'Et', 'Eta', 'Phi']
-        trackerJet: ['Pt', 'Eta', 'Phi']
+        seededConePuppiJet: [Pt, Et, Eta, Phi]
+        trackerJet: [Pt, Eta, Phi]
         phase1PuppiJet: "all"
         # caloJet: "all"
   VBFHToTauTau:
     ntuple_path: /eos/cms/store/cmst3/group/l1tr/phase2Menu/EmuDev/VBFHToTauTau_M125_14TeV_powheg_pythia8_correctedGridpack_tuneCP5/VBFToTauTau_PU200_v22/220407_095503/0000//L1NtuplePhaseII_Step1_*.root
-    trees_branches: {}
+    trees_branches:
+      genTree/L1GenTree:
+        part_tau: [Id, Stat, Pt, Eta, Phi, Parent, E]
+      l1PhaseIITree/L1PhaseIITree:
+        nnTau: [Et, Eta, Pt, Phi, FullIso, Z0, PassTightNN, Chg, DXY, PassLooseNN]
+        caloTau: [Et, Eta, Pt, Phi, Iso, HwQual, Bx]
   GluGluToGG:
     ntuple_path: /eos/cms/store/cmst3/group/l1tr/phase2Menu/EmuDev/GluGluHToGG_M125_14TeV_powheg_pythia8_TuneCP5/HGG_PU200_v22/220407_094856/0000//L1NtuplePhaseII_Step1_*.root
     trees_branches:
       genTree/L1GenTree:
         part_gamma: [Id, Stat, Pt, Eta, Phi]
       l1PhaseIITree/L1PhaseIITree:
-        tkPhoton: ['Pt', 'Et', 'Eta', 'Phi', 'Bx', 'TrkIso', 'HwQual', 'HGC', 'PassesPhotonID']
+        tkPhoton: [Pt, Et, Eta, Phi, Bx, TrkIso, HwQual, HGC, PassesPhotonID]
   GluGluToHHTo2B2Tau:
     ntuple_path: /eos/cms/store/cmst3/group/l1tr/phase2Menu/EmuDev/GluGluToHHTo2B2Tau_node_SM_TuneCP5_14TeV-madgraph-pythia8/GGToHHTo2B2Tau_PU200_v22/220408_073133/0000//L1NtuplePhaseII_Step1_*.root
     trees_branches:

--- a/objectPerformance/cfg_plots/electron_matching.yaml
+++ b/objectPerformance/cfg_plots/electron_matching.yaml
@@ -12,9 +12,17 @@ ElectronsMatchingBarrel:
       object:
         - "abs({eta}) < 2.4"
   test_objects:
+    EG:
+      suffix: "Pt"
+      label: "EG Electron"
+      match_dR: 0.2
+      cuts:
+        - "abs({eta}) < 2.4"
+        - "{passesloosetrackid} == 1"
     tkElectron:
       suffix: "Pt"
       label: "TkElectron"
+      match_dR: 0.15
       cuts:
         - "abs({eta}) < 2.4"
         - "{passesloosetrackid} == 1"
@@ -29,7 +37,6 @@ ElectronsMatchingBarrel:
     #    - "abs({eta}) < 2.4"
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (Barrel)"
-  match_dR: 0.15
   binning:
     min: 0
     max: 150
@@ -49,15 +56,22 @@ ElectronsMatchingEndcap:
       object:
         - "abs({eta}) < 2.4"
   test_objects:
+    EG:
+      suffix: "Pt"
+      label: "EG Electron"
+      match_dR: 0.2
+      cuts:
+        - "abs({eta}) < 2.4"
+        - "{passesloosetrackid} == 1"
     tkElectron:
       suffix: "Pt"
       label: "TkElectron"
+      match_dR: 0.15
       cuts:
         - "abs({eta}) < 2.4"
         - "{passesloosetrackid} == 1"
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Matching Efficiency (Endcap)"
-  match_dR: 0.15
   binning:
     min: 0
     max: 150

--- a/objectPerformance/cfg_plots/electron_matching_eta.yaml
+++ b/objectPerformance/cfg_plots/electron_matching_eta.yaml
@@ -13,7 +13,15 @@ ElectronsMatching_Eta_Pt10to25:
       object:
         - "abs({eta}) < 2.8"
   test_objects:
+    EG:
+      suffix: "Eta"
+      label: "EG Electron"
+      match_dR: 0.2
+      cuts:
+        - "abs({eta}) < 2.4"
+        - "{passesloosetrackid} == 1"
     tkElectron:
+      match_dR: 0.15
       suffix: "Eta"
       label: "TkElectron"
       quality_id: "QUAL_BarrelNoneEndcap3"
@@ -22,7 +30,6 @@ ElectronsMatching_Eta_Pt10to25:
         - "{passesloosetrackid} == 1"
   xlabel: "Gen. $\\eta$"
   ylabel: "Matching Efficiency ($10 < p_T < 25$ GeV)"
-  match_dR: 0.15
   binning:
     min: -3
     max: 3
@@ -42,15 +49,22 @@ ElectronsMatching_Eta_Pt25toInf:
       object:
         - "abs({eta}) < 2.8"
   test_objects:
+    EG:
+      suffix: "Eta"
+      label: "EG Electron"
+      match_dR: 0.2
+      cuts:
+        - "abs({eta}) < 2.4"
+        - "{passesloosetrackid} == 1"
     tkElectron:
       suffix: "Eta"
       label: "TkElectron"
+      match_dR: 0.15
       cuts:
         - "abs({eta}) < 2.8"
         - "{passesloosetrackid} == 1"
   xlabel: "Gen. $\\eta$"
   ylabel: "Matching Efficiency ($p_T > 25$ GeV)"
-  match_dR: 0.15
   binning:
     min: -3
     max: 3

--- a/objectPerformance/cfg_plots/electron_trigger.yaml
+++ b/objectPerformance/cfg_plots/electron_trigger.yaml
@@ -12,6 +12,13 @@ ElectronsTriggerBarrel:
       object:
         - "abs({eta}) < 2.8"
   test_objects:
+    EG:
+      suffix: "Pt"
+      label: "EG Electron"
+      match_dR: 0.2
+      cuts:
+        - "abs({eta}) < 2.8"
+        - "{passesloosetrackid} == 1"
     tkElectron:
       suffix: "Pt"
       label: "tkElectron"
@@ -44,6 +51,13 @@ ElectronsTriggerEndcap:
       object:
         - "abs({eta}) < 2.8"
   test_objects:
+    EG:
+      suffix: "Pt"
+      label: "EG Electron"
+      match_dR: 0.2
+      cuts:
+        - "abs({eta}) < 2.8"
+        - "{passesloosetrackid} == 1"
     tkElectron:
       suffix: "Pt"
       label: "tkElectron"

--- a/objectPerformance/cfg_plots/jets_matching_eta.yaml
+++ b/objectPerformance/cfg_plots/jets_matching_eta.yaml
@@ -12,6 +12,12 @@ JetMatching_Eta_Pt40To100:
       object:
         - "abs({eta}) < 5"
   test_objects:
+    phase1PuppiJet:
+      match_dR: 0.3
+      suffix: "Pt"
+      label: "Histogrammed PuppiJet"
+      cuts:
+        - "abs({eta}) < 5"
     seededConePuppiJet:
       match_dR: 0.35
       suffix: "Eta"
@@ -44,6 +50,12 @@ JetMatching_Eta_Pt100ToInf:
       object:
         - "abs({eta}) < 2.5"
   test_objects:
+    phase1PuppiJet:
+      match_dR: 0.3
+      suffix: "Pt"
+      label: "Histogrammed PuppiJet"
+      cuts:
+        - "abs({eta}) < 5"
     seededConePuppiJet:
       match_dR: 0.35
       suffix: "Eta"

--- a/objectPerformance/cfg_plots/jets_trigger.yaml
+++ b/objectPerformance/cfg_plots/jets_trigger.yaml
@@ -11,6 +11,12 @@ JetTurnonBarrel:
       object:
         - "abs({eta}) < 2.4"
   test_objects:
+    phase1PuppiJet:
+      match_dR: 0.3
+      suffix: "Pt"
+      label: "Histogrammed PuppiJet"
+      cuts:
+        - "abs({eta}) < 2.4"
     seededConePuppiJet:
       match_dR: 0.35
       suffix: "Pt"
@@ -25,7 +31,7 @@ JetTurnonBarrel:
         - "abs({eta}) < 2.4"
   thresholds: [50]
   scalings:
-    method: "errf"
+    method: "naive"
     threshold: 0.95
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Trigger Efficiency (<threshold> GeV, barrel)"
@@ -47,6 +53,12 @@ JetTurnonEndcap:
       object:
         - "abs({eta}) < 2.4"
   test_objects:
+    phase1PuppiJet:
+      match_dR: 0.3
+      suffix: "Pt"
+      label: "Histogrammed PuppiJet"
+      cuts:
+        - "abs({eta}) < 2.4"
     seededConePuppiJet:
       match_dR: 0.35
       suffix: "Pt"
@@ -59,9 +71,9 @@ JetTurnonEndcap:
       label: "Tracker Jet"
       cuts:
         - "abs({eta}) < 2.4"
-  thresholds: [125]
+  thresholds: [50]
   scalings:
-    method: "errf"
+    method: "naive"
     threshold: 0.95
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Trigger Efficiency (<threshold> GeV, endcap)"
@@ -91,7 +103,7 @@ JetTurnonForward:
         - "abs({eta}) < 5"
   thresholds: [50]
   scalings:
-    method: "errf"
+    method: "naive"
     threshold: 0.95
   xlabel: "Gen. $p_T$ (GeV)"
   ylabel: "Trigger Efficiency (<threshold> GeV, forward)"

--- a/objectPerformance/cfg_plots/met_ht_mht.yaml
+++ b/objectPerformance/cfg_plots/met_ht_mht.yaml
@@ -72,7 +72,7 @@ MET:
     puppiMET:
       suffix: "et"
       label: "Puppi MET"
-  thresholds: [70, 150]
+  thresholds: [150]
   xlabel: "Gen. MET (GeV)"
   ylabel: "Trigger Efficiency (<threshold> GeV)"
   scalings:

--- a/objectPerformance/cfg_plots/tau_matching_GG_VBF.yaml
+++ b/objectPerformance/cfg_plots/tau_matching_GG_VBF.yaml
@@ -1,0 +1,55 @@
+TausMatchingBarrel_HH:
+  sample: GluGluToHHTo2B2Tau
+  default_version: V22
+  reference_object:
+    object: "part_tau"
+    suffix: "Pt"
+    label: "Gen Taus"
+    cuts:
+      event:
+        - "{dr_0.3} < 0.15"
+        - "abs({eta}) < 1.5"
+      object:
+        - "abs({eta}) < 2.4"
+  test_objects:
+    nnTau:
+      suffix: "Pt"
+      label: "NN Tau (HH)"
+      cuts:
+        - "abs({eta}) < 2.4"
+        - "{passloosenn}==1"
+      match_dR: 0.1
+  xlabel: "Gen. $p_T$ (GeV)"
+  ylabel: "Matching Efficiency (Barrel)"
+  binning:
+    min: 0
+    max: 150
+    step: 6
+
+TausMatchingBarrel_H:
+  sample: VBFHToTauTau
+  default_version: V22
+  reference_object:
+    object: "part_tau"
+    suffix: "Pt"
+    label: "Gen Taus"
+    cuts:
+      event:
+        - "{dr_0.3} < 0.15"
+        - "abs({eta}) < 1.5"
+      object:
+        - "abs({eta}) < 2.4"
+  test_objects:
+    nnTau:
+      suffix: "Pt"
+      label: "NN Tau (H)"
+      cuts:
+        - "abs({eta}) < 2.4"
+        - "{passloosenn}==1"
+      match_dR: 0.1
+  xlabel: "Gen. $p_T$ (GeV)"
+  ylabel: "Matching Efficiency (Barrel)"
+  binning:
+    min: 0
+    max: 150
+    step: 6

--- a/objectPerformance/src/cache_objects.py
+++ b/objectPerformance/src/cache_objects.py
@@ -212,7 +212,7 @@ class ObjectCacher():
 
     def _postprocess_branches(self, arr):
         if self._object.startswith("part"):
-            if "tau" in self._object:
+            if "tau" in self._part_type:
                 ref_parts = self._get_visible_taus(arr.copy())
             else:
                 ref_parts = self._filter_genpart_branches(arr.copy())


### PR DESCRIPTION
Includes all the objects in the caching step and in the plotting configs to reproduce the matching efficiency and L1 turnon curves displayed in the [reference presentation](https://twiki.cern.ch/twiki/pub/CMS/PhaseIIL1TriggerMenuTools/Phase2Menu_validation123x-3.pdf)