### PR TITLE
[Iso vs Eff] Implement L1 Iso vs Eff plots for WP studies

### DIFF
--- a/objectPerformance/cfg_plots/electron_iso.yaml
+++ b/objectPerformance/cfg_plots/electron_iso.yaml
@@ -1,0 +1,29 @@
+ElectronsIsolation:
+  sample: DY
+  default_version: V22
+  iso_vs_efficiency: True
+  reference_object:
+    object: "part_e"
+    suffix: "Pt"
+    label: "Gen Electrons"
+    cuts:
+      event:
+        - "{dr_0.3} < 0.15"
+        - "abs({eta}) < 1.5"
+      object:
+        - "abs({eta}) < 2.4"
+  test_objects:
+    tkElectron:
+      suffix: "trkiso"
+      label: "TkElectron"
+      match_dR: 0.15
+      cuts:
+        - "abs({eta}) < 2.4"
+        - "{passesloosetrackid} == 1"
+  xlabel: "Isolation"
+  ylabel: "Efficiency"
+  binning:
+    min: 0
+    max: 1
+    step: 0.005
+

--- a/objectPerformance/src/plot_config.py
+++ b/objectPerformance/src/plot_config.py
@@ -17,6 +17,13 @@ class PlotConfig():
             return None
 
     @property
+    def iso_vs_eff_plot(self):
+        try:
+            return self._cfg["iso_vs_efficiency"]
+        except KeyError:
+            return False
+
+    @property
     def reference_object(self):
         return self._cfg["reference_object"]["object"]
 

--- a/objectPerformance/src/turnon_collection.py
+++ b/objectPerformance/src/turnon_collection.py
@@ -129,7 +129,8 @@ class TurnOnCollection():
             pass_dR = dR < self.cfg_plot.get_match_dR(test_obj)
             pt_max = ak.argmax(ref_test["test"]["pt"][pass_dR], axis=-1,
                                keepdims=True)
-            self.numerators["ref"][test_obj] = ref_test["ref"][suffix][pass_dR][pt_max][:, :, 0]  # noqa
+            if ("iso" not in suffix):
+                self.numerators["ref"][test_obj] = ref_test["ref"][suffix][pass_dR][pt_max][:, :, 0]  # noqa
             self.numerators["test"][test_obj] = ref_test["test"][suffix][pass_dR][pt_max][:, :, 0]  # noqa
 
     def _flatten_array(self, ak_array, ak_to_np=False):
@@ -339,6 +340,15 @@ class TurnOnCollection():
             self.hists["ref"][test_obj] = np.histogram(ref_flat_np,
                                                        bins=self.bins)
 
+    def _skim_to_hists_dR_matched_Iso(self):
+        for test_obj, cfg in self.cfg_plot.test_objects.items():
+            numerator = self.numerators["test"][test_obj]
+            numerator = self._remove_inner_nones_zeros(numerator)
+            numerator = self._flatten_array(numerator, ak_to_np=True)
+
+            # Create Test Object(s) Numpy Histogram
+            self.hists[test_obj] = np.histogram(numerator, bins=self.bins)
+
     def xerr(self, obj_key: str):
         ref_vals = self.hists["ref"][obj_key][0]
         bin_width = self.cfg_plot.bin_width
@@ -372,5 +382,8 @@ class TurnOnCollection():
             self._skim_to_hists()
         else:
             self._match_test_to_ref()
-            self._skim_to_hists_dR_matched()
+            if self.cfg_plot.iso_vs_eff_plot:
+                self._skim_to_hists_dR_matched_Iso()
+            else:
+                self._skim_to_hists_dR_matched()
 


### PR DESCRIPTION
Aims at solving https://github.com/bonanomi/Phase2-L1MenuTools/issues/14.

To run: `./src/plotter.py cfg_plots/electron_trigger.yaml`. Output is documented in https://github.com/bonanomi/Phase2-L1MenuTools/issues/14.

* Introduced `iso_vs_efficiency` field in the config file (necessary only for this kind of plots, otherwise `iso_vs_eff_plot` in `PlotConfig` returns `False`.
* Introduced `_skim_to_hists_dR_matched_Iso` in `turnon_collection` as for this use case we need to build only histograms for the test object(s), after performing the usual dR matching.
* Introduced `_plot_iso_vs_efficiency_curve` in the `plotter`, which runs only for this use case.