### PR TITLE
[V26 Loading] Cache files with large size

### DIFF
--- a/objectPerformance/cfg_caching/V26.yaml
+++ b/objectPerformance/cfg_caching/V26.yaml
@@ -1,0 +1,8 @@
+V26:
+  GluGluToGG:
+    ntuple_path: /eos/cms/store/group/dpg_trigger/comm_trigger/L1Trigger/alobanov/phase2/menu/ntuples/RelVal/CMSSW_12_5_1/Hgg_1251_200PU_condor/NTP/v26_PU200_fixGenMET_EGID//L1Ntuple_7608426_*.root
+    trees_branches:
+      genTree/L1GenTree:
+        part_gamma: [Id, Stat, Pt, Eta, Phi]
+      l1PhaseIITree/L1PhaseIITree:
+        tkPhoton: [Pt, Et, Eta, Phi, Bx, TrkIso, HwQual, HGC, PassesPhoID]

--- a/objectPerformance/cfg_plots/tau_trigger.yaml
+++ b/objectPerformance/cfg_plots/tau_trigger.yaml
@@ -1,5 +1,5 @@
 TauTriggerBarrel:
-  sample: GluGluToGG
+  sample: GluGluToHHTo2B2Tau 
   default_version: V22
   reference_object:
     object: "part_tau"
@@ -37,7 +37,7 @@ TauTriggerBarrel:
     step: 6
 
 TauTriggerEndcap:
-  sample: GluGluToGG
+  sample: GluGluToHHTo2B2Tau 
   default_version: V22
   reference_object:
     object: "part_tau"


### PR DESCRIPTION
This PR aims at solving https://github.com/bonanomi/Phase2-L1MenuTools/issues/16

The loading of the files is now done using `uproot.iterate()` and reading chunks of 100MB, computing the gen-level Iso, and *only after* concatenating arrays. This change also slightly improves the speed of the cache step.